### PR TITLE
Clean up flake8 for ansible.netcommon collection (#65842)

### DIFF
--- a/lib/ansible/module_utils/network/common/config.py
+++ b/lib/ansible/module_utils/network/common/config.py
@@ -30,7 +30,6 @@ import hashlib
 
 from ansible.module_utils.six.moves import zip
 from ansible.module_utils._text import to_bytes, to_native
-from ansible.module_utils.network.common.utils import to_list
 
 DEFAULT_COMMENT_TOKENS = ['#', '!', '/*', '*/', 'echo']
 

--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -35,8 +35,6 @@ import socket
 import json
 
 from itertools import chain
-from socket import inet_aton
-from json import dumps
 
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.common._collections_compat import Mapping
@@ -45,7 +43,9 @@ from ansible.module_utils import basic
 from ansible.module_utils.parsing.convert_bool import boolean
 
 # Backwards compatibility for 3rd party modules
-from ansible.module_utils.common.network import (
+# TODO(pabelanger): With move to ansible.netcommon, we should clean this code
+# up and have modules import directly themself.
+from ansible.module_utils.common.network import (  # noqa: F401
     to_bits, is_netmask, is_masklen, to_netmask, to_masklen, to_subnet, to_ipv6_network, VALID_MASKS
 )
 

--- a/lib/ansible/plugins/action/net_get.py
+++ b/lib/ansible/plugins/action/net_get.py
@@ -17,7 +17,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import copy
 import os
 import re
 import uuid
@@ -37,7 +36,7 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
         socket_path = None
-        network_os = self._get_network_os(task_vars)
+        self._get_network_os(task_vars)
         persistent_connection = self._play_context.connection.split('.')[-1]
 
         result = super(ActionModule, self).run(task_vars=task_vars)

--- a/lib/ansible/plugins/action/net_put.py
+++ b/lib/ansible/plugins/action/net_put.py
@@ -17,7 +17,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import copy
 import os
 import uuid
 import hashlib

--- a/lib/ansible/plugins/action/network.py
+++ b/lib/ansible/plugins/action/network.py
@@ -21,7 +21,6 @@ __metaclass__ = type
 
 import os
 import time
-import glob
 import re
 
 from ansible.errors import AnsibleError

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -329,7 +329,7 @@ class Connection(NetworkConnectionBase):
             self._manager._timeout = self.get_option('persistent_command_timeout')
         except SSHUnknownHostError as exc:
             raise AnsibleConnectionFailure(to_native(exc))
-        except ImportError as exc:
+        except ImportError:
             raise AnsibleError("connection=netconf is not supported on {0}".format(self._network_os))
 
         if not self._manager.connected:

--- a/lib/ansible/plugins/httpapi/restconf.py
+++ b/lib/ansible/plugins/httpapi/restconf.py
@@ -42,7 +42,6 @@ options:
 import json
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.network.common.utils import to_list
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.plugins.httpapi import HttpApiBase

--- a/lib/ansible/plugins/netconf/default.py
+++ b/lib/ansible/plugins/netconf/default.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 import json
 
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils._text import to_text
 from ansible.plugins.netconf import NetconfBase
 
 

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -127,7 +127,7 @@ class TestConnectionClass(unittest.TestCase):
         """
 
         mock__shell.recv.side_effect = [response, None]
-        output = conn.send(b'command')
+        conn.send(b'command')
 
         mock__shell.sendall.assert_called_with(b'command\r')
         self.assertEqual(to_text(conn._command_response), 'command response')

--- a/test/units/plugins/filter/test_network.py
+++ b/test/units/plugins/filter/test_network.py
@@ -20,8 +20,6 @@ __metaclass__ = type
 import os
 import sys
 
-import pytest
-
 from units.compat import unittest
 from ansible.plugins.filter.network import parse_xml, type5_pw, hash_salt, comp_type5, vlan_parser
 
@@ -141,7 +139,7 @@ class TestHashSalt(unittest.TestCase):
     def test_unparseable_salt(self):
         password = '$nTc1$Z28sUTcWfXlvVe2x.3XAa.'
         with self.assertRaises(Exception) as e:
-            parsed = hash_salt(password)
+            hash_salt(password)
         self.assertEqual("Could not parse salt out password correctly from $nTc1$Z28sUTcWfXlvVe2x.3XAa.", str(e.exception))
 
 


### PR DESCRIPTION
We noticed the following flake8 errors when we ran the migration script
for ansible.netcommon.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
