### PR TITLE
Bugfix of 65761: postgresql_privs fail after it's updated to 2.9.2 (#…

### DIFF
--- a/changelogs/fragments/65903-postgresql_privs_sort_lists_with_none_elements.yml
+++ b/changelogs/fragments/65903-postgresql_privs_sort_lists_with_none_elements.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs - fix sorting lists with None elements for python3 (https://github.com/ansible/ansible/issues/65761).

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -780,8 +780,16 @@ class Connection(object):
         executed_queries.append(query)
         self.cursor.execute(query)
         status_after = get_status(objs)
-        status_before.sort()
-        status_after.sort()
+
+        def nonesorted(e):
+            # For python 3+ that can fail trying
+            # to compare NoneType elements by sort method.
+            if e is None:
+                return ''
+            return e
+
+        status_before.sort(key=nonesorted)
+        status_after.sort(key=nonesorted)
         return status_before != status_after
 
 


### PR DESCRIPTION
…65903)

* Bugfix of 65761: postgresql_privs fail after it's updated to 2.9.2

* add changelog

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
