### PR TITLE
openssl_publickey: forgot to pass backend (#67036)

### DIFF
--- a/changelogs/fragments/67036-openssl_publickey-backend.yml
+++ b/changelogs/fragments/67036-openssl_publickey-backend.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_publickey - fix a module crash caused when pyOpenSSL is not installed (https://github.com/ansible/ansible/issues/67035)."

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -299,7 +299,8 @@ class PublicKey(crypto_utils.OpenSSLObject):
         self.fingerprint = crypto_utils.get_fingerprint(
             path=self.privatekey_path,
             content=self.privatekey_content,
-            passphrase=self.privatekey_passphrase
+            passphrase=self.privatekey_passphrase,
+            backend=self.backend,
         )
         file_args = module.load_file_common_arguments(module.params)
         if module.set_fs_attributes_if_different(file_args, False):


### PR DESCRIPTION
* Forgot to pass backend.

* Add changelog.

* Pass on backend from get_fingerprint.

* Handle cryptography backend in get_fingerprint.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
