### PR TITLE
vmware_guest_network/test: disable the test

### DIFF
--- a/test/integration/targets/vmware_guest_network/aliases
+++ b/test/integration/targets/vmware_guest_network/aliases
@@ -2,3 +2,5 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+# until we figure out why vmware_guest_tools_wait fails in the CI
+disabled


### PR DESCRIPTION
The test fails in the CI with a timeout of vmware_guest_tools_wait. It's
still unclear if this comes from:

- the ESXi environment
- the VM configuration, e.g: the amount of the RAM
- the ISO image itself

Ideally, we should have a light VM with the vmware-tools.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
