### PR TITLE
Allow default network mode, as required for windows containers. (#59597)

### DIFF
--- a/changelogs/fragments/59597-ecs-allow_default_network_mode.yml
+++ b/changelogs/fragments/59597-ecs-allow_default_network_mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ecs_task_definition - Add network_mode=default to support Windows ECS tasks.

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -58,9 +58,11 @@ options:
         description:
             - The Docker networking mode to use for the containers in the task.
             - C(awsvpc) mode was added in Ansible 2.5
+            - Windows containers must use I(network_mode=default), which will utilize docker NAT networking.
+            - Setting I(network_mode=default) for a Linux container will use bridge mode.
         required: false
         default: bridge
-        choices: [ 'bridge', 'host', 'none', 'awsvpc' ]
+        choices: [ 'default', 'bridge', 'host', 'none', 'awsvpc' ]
         version_added: 2.3
         type: str
     task_role_arn:
@@ -265,10 +267,11 @@ class EcsTaskManager:
         params = dict(
             family=family,
             taskRoleArn=task_role_arn,
-            networkMode=network_mode,
             containerDefinitions=container_definitions,
             volumes=volumes
         )
+        if network_mode != 'default':
+            params['networkMode'] = network_mode
         if cpu:
             params['cpu'] = cpu
         if memory:
@@ -330,7 +333,7 @@ def main():
         revision=dict(required=False, type='int'),
         force_create=dict(required=False, default=False, type='bool'),
         containers=dict(required=False, type='list'),
-        network_mode=dict(required=False, default='bridge', choices=['bridge', 'host', 'none', 'awsvpc'], type='str'),
+        network_mode=dict(required=False, default='bridge', choices=['default', 'bridge', 'host', 'none', 'awsvpc'], type='str'),
         task_role_arn=dict(required=False, default='', type='str'),
         execution_role_arn=dict(required=False, default='', type='str'),
         volumes=dict(required=False, type='list'),


### PR DESCRIPTION
* Allow default network option for network_mode, required for windows containers.

* Add change fragment and param description

* Update changelogs/fragments/59597-ecs-allow_default_network_mode.yml

Co-Authored-By: Mark Chappell <mchappel@redhat.com>

* Update lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py

Co-Authored-By: Mark Chappell <mchappel@redhat.com>

* Correct descriptions. Remove whitespaces.

* Remove empty line.

* Add single space after comma

* Update lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py

Co-Authored-By: Mark Chappell <mchappel@redhat.com>

* Update lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py

Co-Authored-By: Mark Chappell <mchappel@redhat.com>

* Update lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py

Co-Authored-By: Mark Chappell <mchappel@redhat.com>

Co-authored-by: kevinsagle <44478308+kevinsagle@users.noreply.github.com>
Co-authored-by: Mark Chappell <mchappel@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
