### PR TITLE
AnsibleAWSModule related cleanup - redshift (#66779)

### DIFF
--- a/changelogs/fragments/66779-redshift-backoff.yml
+++ b/changelogs/fragments/66779-redshift-backoff.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- 'redshift: Add AWSRetry calls for errors outside our control'

--- a/hacking/aws_config/testing_policies/database-policy.json
+++ b/hacking/aws_config/testing_policies/database-policy.json
@@ -12,6 +12,15 @@
             }
         },
         {
+            "Action": "iam:CreateServiceLinkedRole",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::*:role/aws-service-role/redshift.amazonaws.com/AWSServiceRoleForRedshift",
+            "Condition": {
+                "StringLike": {
+                    "iam:AWSServiceName": "redshift.amazonaws.com"}
+                }
+        },
+        {
             "Sid": "AllowRDSReadEverywhere",
             "Effect": "Allow",
             "Action": [

--- a/test/integration/targets/redshift/aliases
+++ b/test/integration/targets/redshift/aliases
@@ -1,3 +1,2 @@
-unstable
 cloud/aws
 shippable/aws/group1


### PR DESCRIPTION
* AnsibleAWSModule related cleanup - redshift

* Apply a backoff on modify_cluster to cope with concurrent operations

* Add AWS 'hacking' policy to allow creation of Redshift ServiceRole

* Adding the retry policies makes the redshift test suite more reliable

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
