### PR TITLE
vmware_guest_register_operation/test: no deprecated mod (#67411)

### DIFF
--- a/test/integration/targets/vmware_guest_register_operation/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_register_operation/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - block:
   - name: gather facts of vm
-    vmware_guest_facts:
+    vmware_guest_info:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -218,7 +218,7 @@
         | length == 1
 
 - name: Gather facts of vm
-  vmware_guest_facts:
+  vmware_guest_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"


### PR DESCRIPTION
Don't use `vmware_guest_facts` to collect the Guest information. The
module is deprecated and replaced by `vmware_guest_info`.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
