### PR TITLE
Refactor aws_kms to bring down the complexity score  (#66037)

### DIFF
--- a/changelogs/fragments/66037-aws_kms.yml
+++ b/changelogs/fragments/66037-aws_kms.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - 'aws_kms: code refactor, some error messages updated'


### PR DESCRIPTION
* Remove dead code key_matches_filter/key_matches_filters

* Fail more cleanly when we don't recognise the 'shape' of KMS policy

* Refactor aws_kms to bring down the complexity

* Minor docs tweaks

* Changelog fragment

* Fixups from review

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
