### PR TITLE
O365 connector_card import from dict_transformations

### DIFF
--- a/lib/ansible/modules/notification/office_365_connector_card.py
+++ b/lib/ansible/modules/notification/office_365_connector_card.py
@@ -134,7 +134,7 @@ RETURN = """
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 OFFICE_365_CARD_CONTEXT = "http://schema.org/extensions"
 OFFICE_365_CARD_TYPE = "MessageCard"


### PR DESCRIPTION
Update office_365_connector_card.py to import snake_dict_to_camel_dict
from common.dict_transformations instead of ec2, to eliminate collection
dependency on AWS collection.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
