### PR TITLE
Split test_play_context_make_become_cmd into files (#68026)

### DIFF
--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -7,7 +7,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import re
 import pytest
 
 from ansible import constants as C
@@ -95,96 +94,18 @@ def test_play_context(mocker, parser, reset_cli_args):
     assert play_context.no_log is False
 
 
-def test_play_context_make_become_cmd(mocker, parser, reset_cli_args):
+def test_play_context_make_become_bad(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
     context._init_global_context(options)
     play_context = PlayContext()
 
     default_cmd = "/bin/foo"
     default_exe = "/bin/bash"
-    sudo_exe = 'sudo'
-    sudo_flags = '-H -s -n'
-    su_exe = 'su'
-    su_flags = ''
-    pbrun_exe = 'pbrun'
-    pbrun_flags = ''
-    pfexec_exe = 'pfexec'
-    pfexec_flags = ''
-    doas_exe = 'doas'
-    doas_flags = '-n'
-    ksu_exe = 'ksu'
-    ksu_flags = ''
-    dzdo_exe = 'dzdo'
-    dzdo_flags = ''
-
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
-    assert cmd == default_cmd
-
-    success = 'BECOME-SUCCESS-.+?'
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('sudo'))
-    play_context.become_flags = sudo_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-
-    assert (re.match("""%s %s  -u %s %s -c 'echo %s; %s'""" % (sudo_exe, sudo_flags, play_context.become_user,
-                                                               default_exe, success, default_cmd), cmd) is not None)
-
-    play_context.become_pass = 'testpass'
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
-    assert (re.match("""%s %s -p "%s" -u %s %s -c 'echo %s; %s'""" % (sudo_exe, sudo_flags.replace('-n', ''),
-                                                                      r"\[sudo via ansible, key=.+?\] password:", play_context.become_user,
-                                                                      default_exe, success, default_cmd), cmd) is not None)
-
-    play_context.become_pass = None
-    play_context.become_method = 'su'
-    play_context.set_become_plugin(become_loader.get('su'))
-    play_context.become_flags = su_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert (re.match("""%s  %s -c '%s -c '"'"'echo %s; %s'"'"''""" % (su_exe, play_context.become_user, default_exe,
-                                                                      success, default_cmd), cmd) is not None)
-
-    play_context.set_become_plugin(become_loader.get('pbrun'))
-    play_context.become_method = 'pbrun'
-    play_context.become_flags = pbrun_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user,
-                                                       success, default_cmd), cmd) is not None
-
-    play_context.set_become_plugin(become_loader.get('pfexec'))
-    play_context.become_method = 'pfexec'
-    play_context.become_flags = pfexec_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
-
-    play_context.set_become_plugin(become_loader.get('doas'))
-    play_context.become_method = 'doas'
-    play_context.become_flags = doas_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, play_context.become_user, default_exe, success,
-                                                              default_cmd), cmd) is not None)
-
-    play_context.set_become_plugin(become_loader.get('ksu'))
-    play_context.become_method = 'ksu'
-    play_context.become_flags = ksu_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, play_context.become_user, ksu_flags,
-                                                              default_exe, success, default_cmd), cmd) is not None)
-
     play_context.set_become_plugin(become_loader.get('bad'))
     play_context.become_method = 'bad'
-    with pytest.raises(AnsibleError):
-        play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
 
-    play_context.set_become_plugin(become_loader.get('dzdo'))
-    play_context.become_method = 'dzdo'
-    play_context.become_flags = dzdo_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, play_context.become_user, default_exe,
-                                                             success, default_cmd), cmd) is not None
-    play_context.become_pass = 'testpass'
-    play_context.set_become_plugin(become_loader.get('dzdo'))
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-    assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, r'\"\[dzdo via ansible, key=.+?\] password:\"',
-                                                                   play_context.become_user, default_exe, success, default_cmd), cmd) is not None
+    with pytest.raises(AnsibleError):
+        play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)

--- a/test/units/plugins/become/conftest.py
+++ b/test/units/plugins/become/conftest.py
@@ -1,0 +1,37 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2017 Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.cli.arguments import option_helpers as opt_help
+from ansible.utils import context_objects as co
+
+
+@pytest.fixture
+def parser():
+    parser = opt_help.create_base_parser('testparser')
+
+    opt_help.add_runas_options(parser)
+    opt_help.add_meta_options(parser)
+    opt_help.add_runtask_options(parser)
+    opt_help.add_vault_options(parser)
+    opt_help.add_async_options(parser)
+    opt_help.add_connect_options(parser)
+    opt_help.add_subset_options(parser)
+    opt_help.add_check_options(parser)
+    opt_help.add_inventory_options(parser)
+
+    return parser
+
+
+@pytest.fixture
+def reset_cli_args():
+    co.GlobalCLIArgs._Singleton__instance = None
+    yield
+    co.GlobalCLIArgs._Singleton__instance = None

--- a/test/units/plugins/become/test_doas.py
+++ b/test/units/plugins/become/test_doas.py
@@ -1,0 +1,39 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2020 Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible import context
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import become_loader
+
+
+def test_doas(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+    play_context = PlayContext()
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    doas_exe = 'doas'
+    doas_flags = '-n'
+
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert cmd == default_cmd
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    play_context.become = True
+    play_context.become_user = 'foo'
+    play_context.set_become_plugin(become_loader.get('doas'))
+    play_context.become_method = 'doas'
+    play_context.become_flags = doas_flags
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, play_context.become_user, default_exe, success,
+                                                              default_cmd), cmd) is not None)

--- a/test/units/plugins/become/test_dzdo.py
+++ b/test/units/plugins/become/test_dzdo.py
@@ -1,0 +1,44 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2020 Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible import context
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import become_loader
+
+
+def test_dzdo(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+    play_context = PlayContext()
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    dzdo_exe = 'dzdo'
+    dzdo_flags = ''
+
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert cmd == default_cmd
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    play_context.become = True
+    play_context.become_user = 'foo'
+    play_context.set_become_plugin(become_loader.get('dzdo'))
+    play_context.become_method = 'dzdo'
+    play_context.become_flags = dzdo_flags
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, play_context.become_user, default_exe,
+                                                             success, default_cmd), cmd) is not None
+    play_context.become_pass = 'testpass'
+    play_context.set_become_plugin(become_loader.get('dzdo'))
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, r'\"\[dzdo via ansible, key=.+?\] password:\"',
+                                                                   play_context.become_user, default_exe, success, default_cmd), cmd) is not None

--- a/test/units/plugins/become/test_ksu.py
+++ b/test/units/plugins/become/test_ksu.py
@@ -1,0 +1,39 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2020 Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible import context
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import become_loader
+
+
+def test_ksu(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+    play_context = PlayContext()
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    ksu_exe = 'ksu'
+    ksu_flags = ''
+
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert cmd == default_cmd
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    play_context.become = True
+    play_context.become_user = 'foo'
+    play_context.set_become_plugin(become_loader.get('ksu'))
+    play_context.become_method = 'ksu'
+    play_context.become_flags = ksu_flags
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, play_context.become_user, ksu_flags,
+                                                              default_exe, success, default_cmd), cmd) is not None)

--- a/test/units/plugins/become/test_pbrun.py
+++ b/test/units/plugins/become/test_pbrun.py
@@ -1,0 +1,39 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2020 Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible import context
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import become_loader
+
+
+def test_pbrun(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+    play_context = PlayContext()
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    pbrun_exe = 'pbrun'
+    pbrun_flags = ''
+
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert cmd == default_cmd
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    play_context.become = True
+    play_context.become_user = 'foo'
+    play_context.set_become_plugin(become_loader.get('pbrun'))
+    play_context.become_method = 'pbrun'
+    play_context.become_flags = pbrun_flags
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user,
+                                                       success, default_cmd), cmd) is not None

--- a/test/units/plugins/become/test_pfexec.py
+++ b/test/units/plugins/become/test_pfexec.py
@@ -1,0 +1,38 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2020 Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible import context
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import become_loader
+
+
+def test_pfexec(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+    play_context = PlayContext()
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    pfexec_exe = 'pfexec'
+    pfexec_flags = ''
+
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert cmd == default_cmd
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    play_context.become = True
+    play_context.become_user = 'foo'
+    play_context.set_become_plugin(become_loader.get('pfexec'))
+    play_context.become_method = 'pfexec'
+    play_context.become_flags = pfexec_flags
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None

--- a/test/units/plugins/become/test_su.py
+++ b/test/units/plugins/become/test_su.py
@@ -1,0 +1,40 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2020 Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible import context
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import become_loader
+
+
+def test_su(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+    play_context = PlayContext()
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    su_exe = 'su'
+    su_flags = ''
+
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert cmd == default_cmd
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    play_context.become = True
+    play_context.become_user = 'foo'
+    play_context.become_pass = None
+    play_context.become_method = 'su'
+    play_context.set_become_plugin(become_loader.get('su'))
+    play_context.become_flags = su_flags
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert (re.match("""%s  %s -c '%s -c '"'"'echo %s; %s'"'"''""" % (su_exe, play_context.become_user, default_exe,
+                                                                      success, default_cmd), cmd) is not None)

--- a/test/units/plugins/become/test_sudo.py
+++ b/test/units/plugins/become/test_sudo.py
@@ -1,0 +1,45 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2020 Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible import context
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import become_loader
+
+
+def test_sudo(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+    play_context = PlayContext()
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    sudo_exe = 'sudo'
+    sudo_flags = '-H -s -n'
+
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert cmd == default_cmd
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    play_context.become = True
+    play_context.become_user = 'foo'
+    play_context.set_become_plugin(become_loader.get('sudo'))
+    play_context.become_flags = sudo_flags
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+
+    assert (re.match("""%s %s  -u %s %s -c 'echo %s; %s'""" % (sudo_exe, sudo_flags, play_context.become_user,
+                                                               default_exe, success, default_cmd), cmd) is not None)
+
+    play_context.become_pass = 'testpass'
+    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert (re.match("""%s %s -p "%s" -u %s %s -c 'echo %s; %s'""" % (sudo_exe, sudo_flags.replace('-n', ''),
+                                                                      r"\[sudo via ansible, key=.+?\] password:", play_context.become_user,
+                                                                      default_exe, success, default_cmd), cmd) is not None)


### PR DESCRIPTION
* Split test_play_context_make_become_cmd into files

For NWO migration. Split the become module assertions into distinct test
files and functions. For now, this is done naively - there is probably
room to abstract these tests out and remove some of the duplication
later on.

Signed-off-by: Rick Elrod <rick@elrod.me>

* use default_exe variable instead of hardcoding /bin/bash

Signed-off-by: Rick Elrod <rick@elrod.me>

* Move become plugin tests to their proper directory and rename them accordingly

Signed-off-by: Rick Elrod <rick@elrod.me>

* Fix up fixtures and imports.

* Remove stray file.

Co-authored-by: Matt Clay <matt@mystile.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
